### PR TITLE
add support for CRD G3 card for NVL platform

### DIFF
--- a/config/linux/ipu8/libcamhal_configs.json
+++ b/config/linux/ipu8/libcamhal_configs.json
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2025-2026 Intel Corporation
+// Copyright (C) 2025 Intel Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,17 +23,7 @@
         "availableSensors": [
             "ov13b10-wf-0",
             "ov13b10-uf-2",
-            "lt6911gxd-1-0",
-            "lt6911gxd-2-2",
-            "isx031-1-0",
-            "isx031-2-0",
-            "isx031-3-0",
-            "isx031-4-0",
-            "isx031-5-2",
-            "isx031-6-2",
-            "isx031-7-2",
-            "isx031-8-2"
-
+            "ov08x40-uf-0"
         ],
         "videoStreamNum" : 2
     }


### PR DESCRIPTION
CRD G3 card got options for 3 sensors.
adding support for sensors available to G3 card.