### PR TITLE
Add unified support for CRD G3 and CRD D1/G1 card

### DIFF
--- a/config/linux/ipu8/libcamhal_configs.json
+++ b/config/linux/ipu8/libcamhal_configs.json
@@ -22,17 +22,9 @@
         //  wf is word facing, and uf is user facing.
         "availableSensors": [
             "ov13b10-wf-0",
+            "ov13b10-wf-1",
             "ov13b10-uf-2",
-            "lt6911gxd-1-0",
-            "lt6911gxd-2-2",
-            "isx031-1-0",
-            "isx031-2-0",
-            "isx031-3-0",
-            "isx031-4-0",
-            "isx031-5-2",
-            "isx031-6-2",
-            "isx031-7-2",
-            "isx031-8-2"
+            "ov13b10-wf-0"
 
         ],
         "videoStreamNum" : 2


### PR DESCRIPTION
NVL HX RVP01 – CRD G3 card Ov13b10 (UF) + Ov13b10 (WF), not required IR sensor for Linux.

NVL HX  RVP03 – CRD D1/G1 Ov13b10 (UF) + Ov13b10 (WF)

Both cards(G3 and D1)  should work without any modification.

availableSensors:
            "ov13b10-wf-0"  //Lane X4
            "ov13b10-wf-1", //Lane : X2
            "ov13b10-uf-2", //Lane X2
            "ov08x40-uf-0"