### PR TITLE
Enable ov08x40 CVS media path for IPU8

### DIFF
--- a/config/linux/ipu8/libcamhal_configs.json
+++ b/config/linux/ipu8/libcamhal_configs.json
@@ -23,6 +23,7 @@
         "availableSensors": [
             "ov13b10-wf-0",
             "ov13b10-uf-2",
+	    "ov08x40-uf-0",
             "lt6911gxd-1-0",
             "lt6911gxd-2-2",
             "isx031-1-0",

--- a/config/linux/ipu8/libcamhal_configs.json
+++ b/config/linux/ipu8/libcamhal_configs.json
@@ -23,6 +23,7 @@
         "availableSensors": [
             "ov13b10-wf-0",
             "ov13b10-uf-2",
+            "ov08x40-uf-0",
             "lt6911gxd-1-0",
             "lt6911gxd-2-2",
             "isx031-1-0",

--- a/config/linux/ipu8/sensors/ov08x40-uf.json
+++ b/config/linux/ipu8/sensors/ov08x40-uf.json
@@ -29,6 +29,14 @@
             "formats": [
               {
                 "name": "ov08x40 $I2CBUS", "pad": 0, "width": 3856, "height": 2176,
+		 "format": "V4L2_MBUS_FMT_SGRBG10_1X10"
+              },
+              {
+                "name": "Intel CVS", "pad": 0, "width": 3856, "height": 2176,
+                "format": "V4L2_MBUS_FMT_SGRBG10_1X10"
+              },
+              {
+                "name": "Intel CVS", "pad": 1, "width": 3856, "height": 2176,
                 "format": "V4L2_MBUS_FMT_SGRBG10_1X10"
               },
               {
@@ -38,7 +46,11 @@
             ],
             "link": [
               {
-                "srcName": "ov08x40 $I2CBUS", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 $CSI_PORT",
+		 "srcName": "ov08x40 $I2CBUS", "srcPad": 0, "sinkName": "Intel CVS",
+                "sinkPad": 0, "enable": true
+              },
+              {
+                "srcName": "Intel CVS", "srcPad": 1, "sinkName": "Intel IPU7 CSI2 $CSI_PORT",
                 "sinkPad": 0, "enable": true
               },
               {

--- a/config/linux/ipu8/sensors/ov08x40-uf.json
+++ b/config/linux/ipu8/sensors/ov08x40-uf.json
@@ -32,13 +32,25 @@
                 "format": "V4L2_MBUS_FMT_SGRBG10_1X10"
               },
               {
+                "name": "Intel CVS", "pad": 0, "width": 3856, "height": 2176,
+                "format": "V4L2_MBUS_FMT_SGRBG10_1X10"
+              },
+              {
+                "name": "Intel CVS", "pad": 1, "width": 3856, "height": 2176,
+                "format": "V4L2_MBUS_FMT_SGRBG10_1X10"
+              },
+              {
                 "name": "Intel IPU7 CSI2 $CSI_PORT", "pad": 0, "width": 3856, "height": 2176,
                 "format": "V4L2_MBUS_FMT_SGRBG10_1X10"
               }
             ],
             "link": [
               {
-                "srcName": "ov08x40 $I2CBUS", "srcPad": 0, "sinkName": "Intel IPU7 CSI2 $CSI_PORT",
+                "srcName": "ov08x40 $I2CBUS", "srcPad": 0, "sinkName": "Intel CVS",
+                "sinkPad": 0, "enable": true
+              },
+              {
+                "srcName": "Intel CVS", "srcPad": 1, "sinkName": "Intel IPU7 CSI2 $CSI_PORT",
                 "sinkPad": 0, "enable": true
               },
               {

--- a/src/v4l2/MediaControl.cpp
+++ b/src/v4l2/MediaControl.cpp
@@ -63,6 +63,7 @@ struct MediaEntity {
     char devname[32];
 };
 
+static const string icvsName = "Intel CVS";
 MediaControl* MediaControl::sInstance = nullptr;
 Mutex MediaControl::sLock;
 
@@ -983,6 +984,33 @@ int MediaControl::mediaCtlSetup(int cameraId, MediaCtlConf* mc, int width, int h
         }
     }
 
+    MediaEntity* icvs = getEntityByName(icvsName.c_str());
+    if (icvs) {
+        for (uint32_t i = 0; i < icvs->numLinks; ++i) {
+            if (icvs->links[i].sink->entity == icvs) {
+                MediaEntity* sensor = icvs->links[i].source->entity;
+                int sensor_entity_id = sensor->info.id;
+                LOG1("@%s, found %s -> %s", __func__, sensor->info.name, icvsName.c_str());
+                for (McLink& link : mc->links) {
+                    if (link.srcEntity == sensor_entity_id && link.sinkEntity != static_cast<int>(icvs->info.id)) {
+                        LOG1("@%s, skip %s, link %s -> %s", __func__, link.srcEntityName.c_str(),
+                             icvsName.c_str(), link.sinkEntityName.c_str());
+                        link.srcEntity = icvs->info.id;
+                        link.srcEntityName = icvsName;
+                        for (uint32_t j = 0; j < icvs->info.pads; ++j) {
+                            if (icvs->pads[j].flags & MEDIA_PAD_FL_SOURCE) {
+                                link.srcPad = j;
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
     /* Set link in format Configuration */
     ret = setMediaMcLink(mc->links);
     CheckAndLogError(ret != OK, ret, "set MediaCtlConf McLink failed: ret = %d", ret);
@@ -1127,6 +1155,9 @@ int MediaControl::getI2CBusAddress(const string& sensorEntityName, const string&
         for (int i = 0; i < linksCount; i++) {
             if (strcmp(links[i].sink->entity->info.name, sinkEntityName.c_str()) == 0) {
                 entityName = entity.info.name;
+		 if (strcmp(entityName, icvsName.c_str()) == 0) {
+                    return getI2CBusAddress(sensorEntityName, icvsName, i2cBus);
+                }
                 break;
             }
         }


### PR DESCRIPTION
Add ov08x40-uf-0 to the available sensor list and update the ov08x40-uf IPU8 sensor topology to include the Intel CVS entity between the ov08x40 sensor and the Intel IPU7 CSI2 receiver.

The media format remains SGRBG10 3856x2176, but the link graph now matches the actual hardware path:

ov08x40 -> Intel CVS -> Intel IPU7 CSI2 -> Intel IPU7 ISYS Capture

This allows Camera HAL/GStreamer to configure the correct media pipeline for ov08x40-uf on the CVS board.